### PR TITLE
たおしたシーンとして保存したあとは、次の保存を3秒間行わない。

### DIFF
--- a/lib/screen/home/usecase/home_on_create_use_case.dart
+++ b/lib/screen/home/usecase/home_on_create_use_case.dart
@@ -67,6 +67,7 @@ class HomeOnCreateUseCase {
               if (_killScene && config.saveWhenKillScene) {
                 _obsRepository.saveReplayBuffer();
                 _stateNotifier.onSaveReplayBuffer(currentTime);
+                baseDelayTime = 3000;
               }
               _killScene = false;
               break;


### PR DESCRIPTION
# 理由

- 同じ動画が多重に保存されているように見えるため。
- インクリングが爆散してから、「○○でやられた」表示まで3秒間の猶予がある。